### PR TITLE
Logik for detecting price jumps changed for price decreases

### DIFF
--- a/app/Console/Commands/detectPriceJumps.php
+++ b/app/Console/Commands/detectPriceJumps.php
@@ -53,7 +53,7 @@ class detectPriceJumps extends Command
             foreach ($hoursAgo as $hourAgo) {
                 $timerange = new Carbon($hourAgo .' hours ago');
 
-                # A "jump" is defined as a 100% price change within a specific timeframe.
+                # A "jump" is defined as a 100% price increase or a 50% price decrease within a specific timeframe.
                 $latestPrices = $coin->value()
                                     ->where('currency_id', $currency->id)
                                     ->where('created_at', '>=', $timerange)
@@ -71,7 +71,7 @@ class detectPriceJumps extends Command
 
                         if ($percentageJump) {
                             # Did the price go up or down?
-                            if ($percentageJump > 100 || $percentageJump < -100) {
+                            if ($percentageJump > 100 || $percentageJump < -50) {
                                 # New jump! Did we already save this one? We only want one per timeframe!
                                 $pricejumps = Pricejump::where('created_at', '>=', $timerange)
                                                         ->where('coin_id', $coin->id)


### PR DESCRIPTION
Since the price percentage jumps now calculates price decreases correctly, this logik should be changed too in order to catch huge negative price jumps (such as a change from 20 to 9.9 - which is a price change <-50%).